### PR TITLE
Fix 'Blocked mirror for repositories: [www2.ph.ed.ac.uk (http://www2.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ All Rights Reserved
   <repositories>
     <repository>
       <id>www2.ph.ed.ac.uk</id>
-      <url>http://www2.ph.ed.ac.uk/maven2</url>
+      <url>https://www2.ph.ed.ac.uk/maven2</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>


### PR DESCRIPTION
The following error occurs when building project with Maven 3.8.1:

```
[ERROR] Failed to execute goal on project qtiworks-jqtiplus: Could not resolve dependencies for project org.openolat.qtiworks:qtiworks-jqtiplus:jar:1.0.22: Failed to collect dependencies at net.sf.saxon:saxon9:jar:9.1.0.8: Failed to read artifact descriptor for net.sf.saxon:saxon9:jar:9.1.0.8: Could not transfer artifact net.sf.saxon:saxon9:pom:9.1.0.8 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [www2.ph.ed.ac.uk (http://www2.ph.ed.ac.uk/maven2, default, releases+snapshots)] -> [Help 1]
```

See https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291 for more details about the error. Currently, defining a mirror in a `~/.m2/settings.xml` file is one workaround for this problem.

I propose using `https` instead of `http` to fix this error for all projects using these artifacts.